### PR TITLE
Relative line numbers are still visible on buffer

### DIFF
--- a/plugin/bufferlist.vim
+++ b/plugin/bufferlist.vim
@@ -113,6 +113,7 @@ function! BufferList()
   setlocal nomodifiable
   setlocal nowrap
   setlocal nonumber
+  setlocal norelativenumber
 
   " set up syntax highlighting
   if has("syntax")


### PR DESCRIPTION
If i am using relativenumber instead of number, then line numbers are visible in buffer list. To solve this issue, plugin should disable relativenumber too.